### PR TITLE
tweaks to data format needed for scraper report

### DIFF
--- a/detections/tls/clienthello/index.ts
+++ b/detections/tls/clienthello/index.ts
@@ -20,7 +20,7 @@ export default class TlsClientHelloPlugin implements IDetectionPlugin {
   public async onNewAssignment(assignment: IAssignment) {
     const forkedServer = new ForkedServerRunner();
     const presitePort = (tlsPort += 1);
-    const sessionid = assignment.sessionid;
+    const sessionid = assignment.sessionId;
     await forkedServer.start(
       presitePort,
       result => this.onTlsResult(result, sessionid),

--- a/profiler/data/browsers.json
+++ b/profiler/data/browsers.json
@@ -1,6 +1,6 @@
 {
-  "chrome_79_0": {
-    "key": "chrome_79_0",
+  "chrome-79-0": {
+    "key": "chrome-79-0",
     "name": "Chrome",
     "desktopPercent": 1.1,
     "version": {
@@ -8,8 +8,8 @@
       "minor": "0"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -20,15 +20,15 @@
             ]
           },
           {
-            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
             "sources": [
               "Intoli"
             ]
           }
         ]
       },
-      "mac_os_x_10_15": {
-        "key": "mac_os_x_10_15",
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -46,8 +46,8 @@
           }
         ]
       },
-      "windows_10": {
-        "key": "windows_10",
+      "windows-10": {
+        "key": "windows-10",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -58,29 +58,15 @@
             ]
           },
           {
-            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36",
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36",
             "sources": [
-              "Intoli"
-            ]
-          },
-          {
-            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
-            "sources": [
-              "Intoli",
-              "Intoli"
-            ]
-          },
-          {
-            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
-            "sources": [
-              "Intoli",
               "Intoli"
             ]
           }
         ]
       },
-      "windows_7": {
-        "key": "windows_7",
+      "windows-7": {
+        "key": "windows-7",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -89,16 +75,48 @@
             "sources": [
               "BrowserStack"
             ]
+          },
+          {
+            "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
           }
         ]
       },
-      "chrome_os_12607_81": {
-        "key": "chrome_os_12607_81",
+      "mac-os-x-10-13": {
+        "key": "mac-os-x-10-13",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "linux": {
+        "key": "linux",
         "desktopPercent": 0,
         "hasBrowserStackSupport": false,
         "useragents": [
           {
-            "string": "Mozilla/5.0 (X11; CrOS x86_64 12607.81.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.119 Safari/537.36",
+            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "mac-os-x-10-12": {
+        "key": "mac-os-x-10-12",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36",
             "sources": [
               "Intoli"
             ]
@@ -107,8 +125,8 @@
       }
     }
   },
-  "chrome_80_0": {
-    "key": "chrome_80_0",
+  "chrome-80-0": {
+    "key": "chrome-80-0",
     "name": "Chrome",
     "desktopPercent": 1.3,
     "version": {
@@ -116,43 +134,27 @@
       "minor": "0"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
           {
             "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
             "sources": [
-              "BrowserStack",
-              "Intoli"
+              "BrowserStack"
             ]
           },
           {
-            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-            "sources": [
-              "Intoli"
-            ]
-          },
-          {
-            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-            "sources": [
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli"
-            ]
-          },
-          {
-            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.100 Safari/537.36",
             "sources": [
               "Intoli"
             ]
           }
         ]
       },
-      "mac_os_x_10_15": {
-        "key": "mac_os_x_10_15",
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -163,110 +165,106 @@
             ]
           },
           {
-            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-            "sources": [
-              "Intoli"
-            ]
-          },
-          {
-            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-            "sources": [
-              "Intoli",
-              "Intoli"
-            ]
-          },
-          {
-            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
             "sources": [
               "Intoli"
             ]
           }
         ]
       },
-      "windows_10": {
-        "key": "windows_10",
+      "windows-10": {
+        "key": "windows-10",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
           {
             "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
             "sources": [
-              "BrowserStack",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli"
+              "BrowserStack"
             ]
           },
           {
             "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-            "sources": [
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli",
-              "Intoli"
-            ]
-          },
-          {
-            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.116 Safari/537.36",
-            "sources": [
-              "Intoli"
-            ]
-          },
-          {
-            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.106 Safari/537.36",
             "sources": [
               "Intoli"
             ]
           }
         ]
       },
-      "windows_7": {
-        "key": "windows_7",
+      "windows-7": {
+        "key": "windows-7",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
           {
             "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
             "sources": [
-              "BrowserStack"
+              "BrowserStack",
+              "Intoli"
             ]
-          },
+          }
+        ]
+      },
+      "linux": {
+        "key": "linux",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": false,
+        "useragents": [
           {
-            "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
+            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.116 Safari/537.36",
             "sources": [
               "Intoli"
             ]
           }
         ]
       },
-      "linux_0": {
-        "key": "linux_0",
+      "mac-os-x-10-12": {
+        "key": "mac-os-x-10-12",
         "desktopPercent": 0,
-        "hasBrowserStackSupport": false,
+        "hasBrowserStackSupport": true,
         "useragents": [
           {
-            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
             "sources": [
-              "Intoli",
               "Intoli"
             ]
-          },
+          }
+        ]
+      },
+      "windows-8-1": {
+        "key": "windows-8-1",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
           {
-            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
+            "string": "Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
             "sources": [
-              "Intoli",
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "mac-os-x-10-13": {
+        "key": "mac-os-x-10-13",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "mac-os-x-10-11": {
+        "key": "mac-os-x-10-11",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+            "sources": [
               "Intoli"
             ]
           }
@@ -274,8 +272,8 @@
       }
     }
   },
-  "chrome_81_0": {
-    "key": "chrome_81_0",
+  "chrome-81-0": {
+    "key": "chrome-81-0",
     "name": "Chrome",
     "desktopPercent": 4,
     "version": {
@@ -283,8 +281,8 @@
       "minor": "0"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -296,8 +294,8 @@
           }
         ]
       },
-      "mac_os_x_10_15": {
-        "key": "mac_os_x_10_15",
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -309,8 +307,8 @@
           }
         ]
       },
-      "windows_10": {
-        "key": "windows_10",
+      "windows-10": {
+        "key": "windows-10",
         "desktopPercent": 2,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -322,8 +320,8 @@
           }
         ]
       },
-      "windows_7": {
-        "key": "windows_7",
+      "windows-7": {
+        "key": "windows-7",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -334,11 +332,24 @@
             ]
           }
         ]
+      },
+      "windows-8-1": {
+        "key": "windows-8-1",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.43 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
       }
     }
   },
-  "chrome_83_0": {
-    "key": "chrome_83_0",
+  "chrome-83-0": {
+    "key": "chrome-83-0",
     "name": "Chrome",
     "desktopPercent": 45.5,
     "version": {
@@ -346,8 +357,8 @@
       "minor": "0"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
         "desktopPercent": 2,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -359,8 +370,8 @@
           }
         ]
       },
-      "mac_os_x_10_15": {
-        "key": "mac_os_x_10_15",
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
         "desktopPercent": 8,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -372,8 +383,8 @@
           }
         ]
       },
-      "windows_10": {
-        "key": "windows_10",
+      "windows-10": {
+        "key": "windows-10",
         "desktopPercent": 28,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -385,8 +396,8 @@
           }
         ]
       },
-      "windows_7": {
-        "key": "windows_7",
+      "windows-7": {
+        "key": "windows-7",
         "desktopPercent": 5,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -400,8 +411,8 @@
       }
     }
   },
-  "edge_83_0": {
-    "key": "edge_83_0",
+  "edge-83-0": {
+    "key": "edge-83-0",
     "name": "Edge",
     "desktopPercent": 4.6,
     "version": {
@@ -409,8 +420,8 @@
       "minor": "0"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -422,8 +433,8 @@
           }
         ]
       },
-      "mac_os_x_10_15": {
-        "key": "mac_os_x_10_15",
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -435,8 +446,8 @@
           }
         ]
       },
-      "windows_10": {
-        "key": "windows_10",
+      "windows-10": {
+        "key": "windows-10",
         "desktopPercent": 2,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -448,8 +459,8 @@
           }
         ]
       },
-      "windows_7": {
-        "key": "windows_7",
+      "windows-7": {
+        "key": "windows-7",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -463,8 +474,8 @@
       }
     }
   },
-  "firefox_76_0": {
-    "key": "firefox_76_0",
+  "firefox-76-0": {
+    "key": "firefox-76-0",
     "name": "Firefox",
     "desktopPercent": 0.7,
     "version": {
@@ -472,8 +483,8 @@
       "minor": "0"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -485,8 +496,8 @@
           }
         ]
       },
-      "mac_os_x_10_15": {
-        "key": "mac_os_x_10_15",
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -498,8 +509,8 @@
           }
         ]
       },
-      "windows_10": {
-        "key": "windows_10",
+      "windows-10": {
+        "key": "windows-10",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -511,8 +522,8 @@
           }
         ]
       },
-      "windows_7": {
-        "key": "windows_7",
+      "windows-7": {
+        "key": "windows-7",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -526,8 +537,8 @@
       }
     }
   },
-  "firefox_77_0": {
-    "key": "firefox_77_0",
+  "firefox-77-0": {
+    "key": "firefox-77-0",
     "name": "Firefox",
     "desktopPercent": 4,
     "version": {
@@ -535,8 +546,8 @@
       "minor": "0"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -548,8 +559,8 @@
           }
         ]
       },
-      "mac_os_x_10_15": {
-        "key": "mac_os_x_10_15",
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -561,8 +572,8 @@
           }
         ]
       },
-      "windows_10": {
-        "key": "windows_10",
+      "windows-10": {
+        "key": "windows-10",
         "desktopPercent": 2,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -574,8 +585,8 @@
           }
         ]
       },
-      "windows_7": {
-        "key": "windows_7",
+      "windows-7": {
+        "key": "windows-7",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -589,8 +600,8 @@
       }
     }
   },
-  "firefox_78_0": {
-    "key": "firefox_78_0",
+  "firefox-78-0": {
+    "key": "firefox-78-0",
     "name": "Firefox",
     "desktopPercent": 1.7,
     "version": {
@@ -598,8 +609,8 @@
       "minor": "0"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -611,8 +622,8 @@
           }
         ]
       },
-      "mac_os_x_10_15": {
-        "key": "mac_os_x_10_15",
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -624,8 +635,8 @@
           }
         ]
       },
-      "windows_10": {
-        "key": "windows_10",
+      "windows-10": {
+        "key": "windows-10",
         "desktopPercent": 1,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -637,8 +648,8 @@
           }
         ]
       },
-      "windows_7": {
-        "key": "windows_7",
+      "windows-7": {
+        "key": "windows-7",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -652,8 +663,8 @@
       }
     }
   },
-  "safari_12_1": {
-    "key": "safari_12_1",
+  "safari-12-1": {
+    "key": "safari-12-1",
     "name": "Safari",
     "desktopPercent": 0.7,
     "version": {
@@ -661,8 +672,8 @@
       "minor": "1"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -673,11 +684,24 @@
             ]
           }
         ]
+      },
+      "mac-os-x-10-12": {
+        "key": "mac-os-x-10-12",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
       }
     }
   },
-  "safari_13_1": {
-    "key": "safari_13_1",
+  "safari-13-1": {
+    "key": "safari-13-1",
     "name": "Safari",
     "desktopPercent": 11.8,
     "version": {
@@ -685,8 +709,8 @@
       "minor": "1"
     },
     "byOsKey": {
-      "mac_os_x_10_15": {
-        "key": "mac_os_x_10_15",
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
         "desktopPercent": 11,
         "hasBrowserStackSupport": true,
         "useragents": [
@@ -700,31 +724,8 @@
       }
     }
   },
-  "edge_18_18363": {
-    "key": "edge_18_18363",
-    "name": "Edge",
-    "version": {
-      "major": "18",
-      "minor": "18363"
-    },
-    "byOsKey": {
-      "windows_10": {
-        "key": "windows_10",
-        "desktopPercent": null,
-        "hasBrowserStackSupport": false,
-        "useragents": [
-          {
-            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18363",
-            "sources": [
-              "BrowserStack"
-            ]
-          }
-        ]
-      }
-    }
-  },
-  "chrome_76_0": {
-    "key": "chrome_76_0",
+  "chrome-76-0": {
+    "key": "chrome-76-0",
     "name": "Chrome",
     "desktopPercent": 0.5,
     "version": {
@@ -732,13 +733,39 @@
       "minor": "0"
     },
     "byOsKey": {
-      "windows_10": {
-        "key": "windows_10",
+      "windows-10": {
+        "key": "windows-10",
         "desktopPercent": 0,
         "hasBrowserStackSupport": true,
         "useragents": [
           {
-            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.87 Safari/537.36",
+            "sources": [
+              "BrowserStack"
+            ]
+          }
+        ]
+      },
+      "windows-7": {
+        "key": "windows-7",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
             "sources": [
               "Intoli"
             ]
@@ -747,8 +774,119 @@
       }
     }
   },
-  "safari_13_0": {
-    "key": "safari_13_0",
+  "chrome-78-0": {
+    "key": "chrome-78-0",
+    "name": "Chrome",
+    "desktopPercent": 0.4,
+    "version": {
+      "major": "78",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "linux": {
+        "key": "linux",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "edge-80-0": {
+    "key": "edge-80-0",
+    "name": "Edge",
+    "desktopPercent": 0,
+    "version": {
+      "major": "80",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36 Edg/80.0.361.62",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chrome-75-0": {
+    "key": "chrome-75-0",
+    "name": "Chrome",
+    "desktopPercent": 0.3,
+    "version": {
+      "major": "75",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.80 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "safari-13-0": {
+    "key": "safari-13-0",
     "name": "Safari",
     "desktopPercent": 1.6,
     "version": {
@@ -756,9 +894,9 @@
       "minor": "0"
     },
     "byOsKey": {
-      "mac_os_x_10_14": {
-        "key": "mac_os_x_10_14",
-        "desktopPercent": 1,
+      "mac-os-x-10-14": {
+        "key": "mac-os-x-10-14",
+        "desktopPercent": 0,
         "hasBrowserStackSupport": false,
         "useragents": [
           {
@@ -768,25 +906,27 @@
             ]
           }
         ]
-      }
-    }
-  },
-  "chrome_57_0": {
-    "key": "chrome_57_0",
-    "name": "Chrome",
-    "desktopPercent": 0,
-    "version": {
-      "major": "57",
-      "minor": "0"
-    },
-    "byOsKey": {
-      "windows_7": {
-        "key": "windows_7",
-        "desktopPercent": 0,
-        "hasBrowserStackSupport": true,
+      },
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
+        "desktopPercent": 1,
+        "hasBrowserStackSupport": false,
         "useragents": [
           {
-            "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36",
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Safari/605.1.15",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "mac-os-x-10-13": {
+        "key": "mac-os-x-10-13",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15",
             "sources": [
               "Intoli"
             ]
@@ -795,8 +935,108 @@
       }
     }
   },
-  "chrome_73_0": {
-    "key": "chrome_73_0",
+  "chrome-72-0": {
+    "key": "chrome-72-0",
+    "name": "Chrome",
+    "desktopPercent": 0.4,
+    "version": {
+      "major": "72",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "linux": {
+        "key": "linux",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chrome-77-0": {
+    "key": "chrome-77-0",
+    "name": "Chrome",
+    "desktopPercent": 0.2,
+    "version": {
+      "major": "77",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "linux": {
+        "key": "linux",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "windows-7": {
+        "key": "windows-7",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chrome-73-0": {
+    "key": "chrome-73-0",
     "name": "Chrome",
     "desktopPercent": 0.2,
     "version": {
@@ -804,13 +1044,13 @@
       "minor": "0"
     },
     "byOsKey": {
-      "linux_0": {
-        "key": "linux_0",
+      "windows-7": {
+        "key": "windows-7",
         "desktopPercent": 0,
-        "hasBrowserStackSupport": false,
+        "hasBrowserStackSupport": true,
         "useragents": [
           {
-            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Safari/537.36",
+            "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36",
             "sources": [
               "Intoli"
             ]
@@ -819,21 +1059,307 @@
       }
     }
   },
-  "chromium_80_0": {
-    "key": "chromium_80_0",
+  "yandex-browser-20-2": {
+    "key": "yandex-browser-20-2",
+    "name": "Yandex Browser",
+    "version": {
+      "major": "20",
+      "minor": "2"
+    },
+    "byOsKey": {
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
+        "desktopPercent": null,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 YaBrowser/20.2.0.1145 Yowser/2.5 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": null,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 YaBrowser/20.2.3.211 Yowser/2.5 Yptp/1.21 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chromium-80-0": {
+    "key": "chromium-80-0",
     "name": "Chromium",
     "version": {
       "major": "80",
       "minor": "0"
     },
     "byOsKey": {
-      "ubuntu_0": {
-        "key": "ubuntu_0",
+      "linux": {
+        "key": "linux",
         "desktopPercent": null,
         "hasBrowserStackSupport": false,
         "useragents": [
           {
-            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/80.0.3987.87 Chrome/80.0.3987.87 Safari/537.36",
+            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) snap Chromium/80.0.3987.132 Chrome/80.0.3987.132 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chrome-70-0": {
+    "key": "chrome-70-0",
+    "name": "Chrome",
+    "desktopPercent": 0.4,
+    "version": {
+      "major": "70",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      },
+      "linux": {
+        "key": "linux",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "opera-66-0": {
+    "key": "opera-66-0",
+    "name": "Opera",
+    "version": {
+      "major": "66",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": null,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36 OPR/66.0.3515.115",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "opera-67-0": {
+    "key": "opera-67-0",
+    "name": "Opera",
+    "version": {
+      "major": "67",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "linux": {
+        "key": "linux",
+        "desktopPercent": null,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36 OPR/67.0.3575.53",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chrome-60-0": {
+    "key": "chrome-60-0",
+    "name": "Chrome",
+    "desktopPercent": 0,
+    "version": {
+      "major": "60",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "ie-11-0": {
+    "key": "ie-11-0",
+    "name": "IE",
+    "desktopPercent": 3.6,
+    "version": {
+      "major": "11",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "windows-7": {
+        "key": "windows-7",
+        "desktopPercent": 3,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chrome-65-0": {
+    "key": "chrome-65-0",
+    "name": "Chrome",
+    "desktopPercent": 0.1,
+    "version": {
+      "major": "65",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chrome-74-0": {
+    "key": "chrome-74-0",
+    "name": "Chrome",
+    "desktopPercent": 0.1,
+    "version": {
+      "major": "74",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "linux": {
+        "key": "linux",
+        "desktopPercent": null,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chrome-82-0": {
+    "key": "chrome-82-0",
+    "name": "Chrome",
+    "version": {
+      "major": "82",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "windows-10": {
+        "key": "windows-10",
+        "desktopPercent": null,
+        "hasBrowserStackSupport": false,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/82.0.4083.0 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "chrome-71-0": {
+    "key": "chrome-71-0",
+    "name": "Chrome",
+    "desktopPercent": 0.4,
+    "version": {
+      "major": "71",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "windows-7": {
+        "key": "windows-7",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+            "sources": [
+              "Intoli"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "edge-81-0": {
+    "key": "edge-81-0",
+    "name": "Edge",
+    "desktopPercent": 0.2,
+    "version": {
+      "major": "81",
+      "minor": "0"
+    },
+    "byOsKey": {
+      "mac-os-x-10-15": {
+        "key": "mac-os-x-10-15",
+        "desktopPercent": 0,
+        "hasBrowserStackSupport": true,
+        "useragents": [
+          {
+            "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.34 Safari/537.36 Edg/81.0.416.20",
             "sources": [
               "Intoli"
             ]

--- a/profiler/data/browsersToTest.json
+++ b/profiler/data/browsersToTest.json
@@ -1,230 +1,1071 @@
-{
-  "majority": [
-    {
-      "browserKey": "chrome_83_0",
-      "osKey": "windows_10",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
-          "usagePercent": 28
-        }
-      ]
+[
+  {
+    "browserKey": "chrome-83-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "majority"
+    ],
+    "usagePercent": {
+      "majority": 28,
+      "random": 0
     },
-    {
-      "browserKey": "safari_13_1",
-      "osKey": "mac_os_x_10_15",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Safari/605.1.15",
-          "usagePercent": 11
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "safari-13-1",
+    "osKey": "mac-os-x-10-15",
+    "pickType": [
+      "majority"
+    ],
+    "usagePercent": {
+      "majority": 11,
+      "random": 0
     },
-    {
-      "browserKey": "chrome_83_0",
-      "osKey": "mac_os_x_10_15",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
-          "usagePercent": 8
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Safari/605.1.15",
+        "sources": [
+          "BrowserStack"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-83-0",
+    "osKey": "mac-os-x-10-15",
+    "pickType": [
+      "majority"
+    ],
+    "usagePercent": {
+      "majority": 8,
+      "random": 0
     },
-    {
-      "browserKey": "chrome_83_0",
-      "osKey": "windows_7",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
-          "usagePercent": 5
-        }
-      ]
-    }
-  ],
-  "intoli": [
-    {
-      "browserKey": "safari_13_0",
-      "osKey": "mac_os_x_10_14",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-83-0",
+    "osKey": "windows-7",
+    "pickType": [
+      "majority"
+    ],
+    "usagePercent": {
+      "majority": 5,
+      "random": 0
     },
-    {
-      "browserKey": "chrome_79_0",
-      "osKey": "mac_os_x_10_14",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "ie-11-0",
+    "osKey": "windows-7",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_79_0",
-      "osKey": "mac_os_x_10_15",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "safari-13-0",
+    "osKey": "mac-os-x-10-15",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_79_0",
-      "osKey": "windows_10",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36",
-          "usagePercent": 2
-        },
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
-          "usagePercent": 4
-        },
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
-          "usagePercent": 4
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Safari/605.1.15",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-79-0",
+    "osKey": "mac-os-x-10-14",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_79_0",
-      "osKey": "chrome_os_12607_81",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (X11; CrOS x86_64 12607.81.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.119 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      },
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-79-0",
+    "osKey": "mac-os-x-10-15",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_80_0",
-      "osKey": "mac_os_x_10_14",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
-          "usagePercent": 2
-        },
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-          "usagePercent": 2
-        },
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-          "usagePercent": 8
-        },
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      },
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-79-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_80_0",
-      "osKey": "mac_os_x_10_15",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-          "usagePercent": 2
-        },
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-          "usagePercent": 4
-        },
-        {
-          "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      },
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-79-0",
+    "osKey": "windows-7",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_80_0",
-      "osKey": "windows_10",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
-          "usagePercent": 22
-        },
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-          "usagePercent": 16
-        },
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.116 Safari/537.36",
-          "usagePercent": 2
-        },
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.106 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      },
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-79-0",
+    "osKey": "mac-os-x-10-13",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_80_0",
-      "osKey": "windows_7",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-79-0",
+    "osKey": "linux",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_80_0",
-      "osKey": "linux_0",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
-          "usagePercent": 4
-        },
-        {
-          "useragent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
-          "usagePercent": 4
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-79-0",
+    "osKey": "mac-os-x-10-12",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_76_0",
-      "osKey": "windows_10",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-80-0",
+    "osKey": "mac-os-x-10-14",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_57_0",
-      "osKey": "windows_7",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      },
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.100 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-80-0",
+    "osKey": "mac-os-x-10-15",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chrome_73_0",
-      "osKey": "linux_0",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      },
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-80-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
     },
-    {
-      "browserKey": "chromium_80_0",
-      "osKey": "ubuntu_0",
-      "agents": [
-        {
-          "useragent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/80.0.3987.87 Chrome/80.0.3987.87 Safari/537.36",
-          "usagePercent": 2
-        }
-      ]
-    }
-  ]
-}
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "sources": [
+          "BrowserStack"
+        ]
+      },
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-80-0",
+    "osKey": "windows-7",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "sources": [
+          "BrowserStack",
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-80-0",
+    "osKey": "linux",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.116 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-80-0",
+    "osKey": "mac-os-x-10-12",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-80-0",
+    "osKey": "windows-8-1",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-80-0",
+    "osKey": "mac-os-x-10-13",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-80-0",
+    "osKey": "mac-os-x-10-11",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-81-0",
+    "osKey": "windows-8-1",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.43 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "safari-12-1",
+    "osKey": "mac-os-x-10-12",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-76-0",
+    "osKey": "windows-7",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-76-0",
+    "osKey": "mac-os-x-10-14",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-78-0",
+    "osKey": "linux",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-78-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-78-0",
+    "osKey": "mac-os-x-10-14",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "edge-80-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36 Edg/80.0.361.62",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-75-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-75-0",
+    "osKey": "mac-os-x-10-14",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.80 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "safari-13-0",
+    "osKey": "mac-os-x-10-14",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "safari-13-0",
+    "osKey": "mac-os-x-10-13",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-72-0",
+    "osKey": "linux",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-72-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-77-0",
+    "osKey": "linux",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-77-0",
+    "osKey": "mac-os-x-10-15",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-77-0",
+    "osKey": "windows-7",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-77-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-73-0",
+    "osKey": "windows-7",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "yandex-browser-20-2",
+    "osKey": "mac-os-x-10-15",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 YaBrowser/20.2.0.1145 Yowser/2.5 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "yandex-browser-20-2",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 YaBrowser/20.2.3.211 Yowser/2.5 Yptp/1.21 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chromium-80-0",
+    "osKey": "linux",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) snap Chromium/80.0.3987.132 Chrome/80.0.3987.132 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-70-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-70-0",
+    "osKey": "linux",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "opera-66-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36 OPR/66.0.3515.115",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "opera-67-0",
+    "osKey": "linux",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36 OPR/67.0.3575.53",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-60-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-65-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-74-0",
+    "osKey": "linux",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-82-0",
+    "osKey": "windows-10",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/82.0.4083.0 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "chrome-71-0",
+    "osKey": "windows-7",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  },
+  {
+    "browserKey": "edge-81-0",
+    "osKey": "mac-os-x-10-15",
+    "pickType": [
+      "random"
+    ],
+    "usagePercent": {
+      "majority": 0,
+      "random": 2
+    },
+    "useragents": [
+      {
+        "string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.34 Safari/537.36 Edg/81.0.416.20",
+        "sources": [
+          "Intoli"
+        ]
+      }
+    ]
+  }
+]

--- a/profiler/data/extra/osTranslations.json
+++ b/profiler/data/extra/osTranslations.json
@@ -1,0 +1,5 @@
+{
+  "ubuntu-0": "linux",
+  "chrome-os-12607-81": "chrome-os-81",
+  "chrome-os-12607-82": "chrome-os-82"
+}

--- a/profiler/data/extra/oses.json
+++ b/profiler/data/extra/oses.json
@@ -1,0 +1,29 @@
+{
+  "linux": {
+    "key": "linux",
+    "name": "Linux",
+    "desktopPercent": 0,
+    "version": {
+      "major": 0,
+      "minor": 0
+    }
+  },
+  "chrome-os-81": {
+    "key": "chrome-os-81",
+    "name": "ChromeOS",
+    "desktopPercent": 0,
+    "version": {
+      "major": 81,
+      "minor": 0
+    }
+  },
+  "chrome-os-82": {
+    "key": "chrome-os-82",
+    "name": "ChromeOS",
+    "desktopPercent": 0,
+    "version": {
+      "major": 82,
+      "minor": 0
+    }
+  }
+}

--- a/profiler/data/oses.json
+++ b/profiler/data/oses.json
@@ -1,6 +1,6 @@
 {
-  "mac_os_x_10_15": {
-    "key": "mac_os_x_10_15",
+  "mac-os-x-10-15": {
+    "key": "mac-os-x-10-15",
     "name": "Mac OS X",
     "desktopPercent": 16.2,
     "version": {
@@ -9,8 +9,8 @@
       "name": "Catalina"
     }
   },
-  "mac_os_x_10_14": {
-    "key": "mac_os_x_10_14",
+  "mac-os-x-10-14": {
+    "key": "mac-os-x-10-14",
     "name": "Mac OS X",
     "desktopPercent": 4.4,
     "version": {
@@ -19,8 +19,8 @@
       "name": "Mojave"
     }
   },
-  "mac_os_x_10_13": {
-    "key": "mac_os_x_10_13",
+  "mac-os-x-10-13": {
+    "key": "mac-os-x-10-13",
     "name": "Mac OS X",
     "desktopPercent": 2.9,
     "version": {
@@ -29,8 +29,8 @@
       "name": "High Sierra"
     }
   },
-  "mac_os_x_10_12": {
-    "key": "mac_os_x_10_12",
+  "mac-os-x-10-12": {
+    "key": "mac-os-x-10-12",
     "name": "Mac OS X",
     "desktopPercent": 1.2,
     "version": {
@@ -39,8 +39,8 @@
       "name": "Sierra"
     }
   },
-  "mac_os_x_10_11": {
-    "key": "mac_os_x_10_11",
+  "mac-os-x-10-11": {
+    "key": "mac-os-x-10-11",
     "name": "Mac OS X",
     "desktopPercent": 1.1,
     "version": {
@@ -49,8 +49,8 @@
       "name": "El Capitan"
     }
   },
-  "mac_os_x_10_10": {
-    "key": "mac_os_x_10_10",
+  "mac-os-x-10-10": {
+    "key": "mac-os-x-10-10",
     "name": "Mac OS X",
     "desktopPercent": 1,
     "version": {
@@ -58,8 +58,8 @@
       "minor": "10"
     }
   },
-  "mac_os_x_10_9": {
-    "key": "mac_os_x_10_9",
+  "mac-os-x-10-9": {
+    "key": "mac-os-x-10-9",
     "name": "Mac OS X",
     "desktopPercent": 0.2,
     "version": {
@@ -68,8 +68,8 @@
       "name": "Mavericks"
     }
   },
-  "mac_os_x_10_6": {
-    "key": "mac_os_x_10_6",
+  "mac-os-x-10-6": {
+    "key": "mac-os-x-10-6",
     "name": "Mac OS X",
     "desktopPercent": 0.1,
     "version": {
@@ -78,8 +78,8 @@
       "name": "Snow Leopard"
     }
   },
-  "mac_os_x_10_7": {
-    "key": "mac_os_x_10_7",
+  "mac-os-x-10-7": {
+    "key": "mac-os-x-10-7",
     "name": "Mac OS X",
     "desktopPercent": 0.1,
     "version": {
@@ -88,8 +88,8 @@
       "name": "Lion"
     }
   },
-  "mac_os_x_10_8": {
-    "key": "mac_os_x_10_8",
+  "mac-os-x-10-8": {
+    "key": "mac-os-x-10-8",
     "name": "Mac OS X",
     "desktopPercent": 0,
     "version": {
@@ -98,8 +98,8 @@
       "name": "Mountain Lion"
     }
   },
-  "mac_os_x_10_5": {
-    "key": "mac_os_x_10_5",
+  "mac-os-x-10-5": {
+    "key": "mac-os-x-10-5",
     "name": "Mac OS X",
     "desktopPercent": 0,
     "version": {
@@ -108,8 +108,8 @@
       "name": "Leopard"
     }
   },
-  "other_0_0": {
-    "key": "other_0_0",
+  "other": {
+    "key": "other",
     "name": "Other",
     "desktopPercent": 0,
     "version": {
@@ -118,24 +118,24 @@
       "minor": "0"
     }
   },
-  "windows_10": {
-    "key": "windows_10",
+  "windows-10": {
+    "key": "windows-10",
     "name": "Windows",
     "desktopPercent": 52.5,
     "version": {
       "major": "10"
     }
   },
-  "windows_7": {
-    "key": "windows_7",
+  "windows-7": {
+    "key": "windows-7",
     "name": "Windows",
     "desktopPercent": 9.6,
     "version": {
       "major": "7"
     }
   },
-  "windows_8_1": {
-    "key": "windows_8_1",
+  "windows-8-1": {
+    "key": "windows-8-1",
     "name": "Windows",
     "desktopPercent": 2.7,
     "version": {
@@ -143,8 +143,8 @@
       "minor": "1"
     }
   },
-  "windows_6_0": {
-    "key": "windows_6_0",
+  "windows-6-0": {
+    "key": "windows-6-0",
     "name": "Windows",
     "desktopPercent": 1.2,
     "version": {
@@ -153,16 +153,16 @@
       "name": "Vista"
     }
   },
-  "windows_8": {
-    "key": "windows_8",
+  "windows-8": {
+    "key": "windows-8",
     "name": "Windows",
     "desktopPercent": 0.7,
     "version": {
       "major": "8"
     }
   },
-  "windows_5_2": {
-    "key": "windows_5_2",
+  "windows-5-2": {
+    "key": "windows-5-2",
     "name": "Windows",
     "desktopPercent": 0.4,
     "version": {
@@ -171,12 +171,39 @@
       "name": "XP"
     }
   },
-  "windows_2003": {
-    "key": "windows_2003",
+  "windows-2003": {
+    "key": "windows-2003",
     "name": "Windows",
     "desktopPercent": 0,
     "version": {
       "major": "2003"
+    }
+  },
+  "linux": {
+    "key": "linux",
+    "name": "Linux",
+    "desktopPercent": 0,
+    "version": {
+      "major": 0,
+      "minor": 0
+    }
+  },
+  "chrome-os-81": {
+    "key": "chrome-os-81",
+    "name": "ChromeOS",
+    "desktopPercent": 0,
+    "version": {
+      "major": 81,
+      "minor": 0
+    }
+  },
+  "chrome-os-82": {
+    "key": "chrome-os-82",
+    "name": "ChromeOS",
+    "desktopPercent": 0,
+    "version": {
+      "major": 82,
+      "minor": 0
     }
   }
 }

--- a/profiler/index.ts
+++ b/profiler/index.ts
@@ -1,4 +1,4 @@
-import { IOperatingSystem } from './lib/Oses';
+import IOperatingSystem from './interfaces/IOperatingSystem';
 import IBrowser from './interfaces/IBrowser';
 import { createOsKey, createOsKeyFromUseragent } from './lib/OsUtils';
 import { createBrowserKey, createBrowserKeyFromUseragent } from './lib/BrowserUtils';
@@ -6,11 +6,11 @@ import { createBrowserKey, createBrowserKeyFromUseragent } from './lib/BrowserUt
 export function getProfileDirNameFromUseragent(useragent: string) {
   const osKey = createOsKeyFromUseragent(useragent);
   const browserKey = createBrowserKeyFromUseragent(useragent);
-  return `${osKey}__${browserKey}`;
+  return `${osKey}--${browserKey}`;
 }
 
 export function getProfileDirName(os: IOperatingSystem, browser: IBrowser) {
   const osKey = createOsKey(os);
   const browserKey = createBrowserKey(browser);
-  return `${osKey}__${browserKey}`;
+  return `${osKey}--${browserKey}`;
 }

--- a/profiler/interfaces/IBrowserOperatingSystem.ts
+++ b/profiler/interfaces/IBrowserOperatingSystem.ts
@@ -1,9 +1,8 @@
+import IBrowserUseragent from './IBrowserUseragent';
+
 export default interface IBrowserOperatingSystem {
   key: string;
   desktopPercent: number;
   hasBrowserStackSupport: boolean;
-  useragents: {
-    string: string;
-    sources: string[];
-  }[];
+  useragents: IBrowserUseragent[];
 }

--- a/profiler/interfaces/IBrowserUseragent.ts
+++ b/profiler/interfaces/IBrowserUseragent.ts
@@ -1,0 +1,6 @@
+export default interface IBrowserUseragent {
+  string: string;
+  sources: IBrowserUseragentSource[];
+}
+
+export type IBrowserUseragentSource = 'BrowserStack' | 'Intoli';

--- a/profiler/interfaces/IOperatingSystem.ts
+++ b/profiler/interfaces/IOperatingSystem.ts
@@ -1,0 +1,8 @@
+import IOperatingSystemVersion from './IOperatingSystemVersion';
+
+export default interface IOperatingSystem {
+  key: string;
+  name: string;
+  desktopPercent: number;
+  version: IOperatingSystemVersion;
+}

--- a/profiler/interfaces/IOperatingSystemVersion.ts
+++ b/profiler/interfaces/IOperatingSystemVersion.ts
@@ -1,0 +1,5 @@
+export default interface IOperatingSystemVersion {
+  major: string;
+  minor: string;
+  name?: string;
+}

--- a/profiler/lib/BrowserStack.ts
+++ b/profiler/lib/BrowserStack.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import IBrowserstackAgent from '../interfaces/IBrowserstackAgent';
 import webdriver from 'selenium-webdriver';
 import IBrowser from '../interfaces/IBrowser';
-import {IOperatingSystem} from "./Oses";
+import IOperatingSystem from '../interfaces/IOperatingSystem';
 
 export default class BrowserStack {
   static supportedCapabilities = [];

--- a/profiler/lib/BrowserUtils.ts
+++ b/profiler/lib/BrowserUtils.ts
@@ -2,7 +2,7 @@ import IBrowser from '../interfaces/IBrowser';
 import { lookup } from 'useragent';
 
 export function createBrowserKey(browser: Pick<IBrowser, 'name' | 'version'>) {
-  return `${browser.name.replace(/\s/g, '_')}_${browser.version.major}_${browser.version.minor}`.toLowerCase()
+  return `${browser.name.replace(/\s/g, '-')}-${browser.version.major}-${browser.version.minor}`.toLowerCase()
 }
 
 export function createBrowserKeyFromUseragent(useragent: string) {

--- a/profiler/lib/Browsers.ts
+++ b/profiler/lib/Browsers.ts
@@ -1,6 +1,5 @@
 import * as Path from 'path';
 import * as Fs from 'fs';
-import IBrowserVersion from '../interfaces/IBrowserVersion';
 import IBrowser from '../interfaces/IBrowser';
 
 export const FILE_PATH = Path.join(__dirname, '../data/browsers.json');

--- a/profiler/lib/BrowsersToTest.ts
+++ b/profiler/lib/BrowsersToTest.ts
@@ -1,22 +1,19 @@
 import * as Path from 'path';
 import * as Fs from 'fs';
+import IBrowserUseragent from "../interfaces/IBrowserUseragent";
 
 export const FILE_PATH = Path.join(__dirname, '../data/browsersToTest.json');
 
 export default class BrowsersToTest {
-  private readonly byType: IByType;
+  private readonly instances: IBrowserToTest[];
 
   constructor() {
     const data = Fs.readFileSync(FILE_PATH, 'utf8');
-    this.byType = JSON.parse(data) as IByType;
+    this.instances = JSON.parse(data) as IBrowserToTest[];
   }
 
-  get majority() {
-    return this.byType.majority;
-  }
-
-  get intoli() {
-    return this.byType.intoli;
+  get all() {
+    return this.instances;
   }
 }
 
@@ -25,15 +22,14 @@ export default class BrowsersToTest {
 export interface IBrowserToTest {
   browserKey: string;
   osKey: string;
-  agents: IBrowserToTestAgent[];
+  pickType: IBrowserToTestPickType;
+  usagePercent: IBrowserToTestUsagePercent;
+  useragents: IBrowserUseragent[];
 }
 
-export interface IBrowserToTestAgent {
-  useragent: string;
-  usagePercent: number;
+export interface IBrowserToTestUsagePercent {
+  majority: number;
+  random: number;
 }
 
-export interface IByType {
-  majority: IBrowserToTest[];
-  intoli: IBrowserToTest[];
-}
+export type IBrowserToTestPickType = ('majority' | 'random')[];

--- a/profiler/lib/OsGenerator.ts
+++ b/profiler/lib/OsGenerator.ts
@@ -1,7 +1,10 @@
 import osVersionsRaw from '../data/statcounter/os_combined.json';
 import macVersions from '../data/statcounter/macos_version.json';
 import winVersions from '../data/statcounter/windows_version.json';
-import { IOperatingSystem, IOperatingSystemVersion, IByKey, FILE_PATH } from './Oses';
+import IOperatingSystem from '../interfaces/IOperatingSystem';
+import IOperatingSystemVersion from '../interfaces/IOperatingSystemVersion';
+import extraOses from '../data/extra/oses.json';
+import { IByKey, FILE_PATH } from './Oses';
 import * as Fs from 'fs';
 import { createOsKey } from './OsUtils';
 
@@ -21,6 +24,10 @@ export default class OsGenerator {
     for (let [rawOsString, rawValues] of Object.entries(winVersions.results)) {
       const os = extractOs(rawOsString, rawValues, winPct)
       this.byKey[os.key] = os;
+    }
+
+    for (const extraOs of Object.values(extraOses)) {
+      if (!this.byKey[extraOs.key]) this.byKey[extraOs.key] = extraOs as unknown as IOperatingSystem;
     }
   }
 

--- a/profiler/lib/OsUtils.ts
+++ b/profiler/lib/OsUtils.ts
@@ -1,11 +1,18 @@
-import {IOperatingSystem} from './Oses';
+import IOperatingSystem from '../interfaces/IOperatingSystem';
+import osTranslations from '../data/extra/osTranslations.json';
 import { lookup } from 'useragent';
 
 export function createOsKey(os: Pick<IOperatingSystem, 'name' | 'version'>) {
-  let tmpKey = `${os.name.replace(/\s/g, '_')}_${os.version.major}`;
-  if (os.version.minor) tmpKey += `_${os.version.minor}`;
+  const name = os.name.toLowerCase();
+  if (['other', 'linux'].includes(name)) {
+    return name;
+  }
 
-  return tmpKey.toLowerCase()
+  let tmpKey = `${name.replace(/\s/g, '-')}-${os.version.major}`;
+  if (os.version.minor) tmpKey += `-${os.version.minor}`;
+  if (osTranslations[tmpKey]) return osTranslations[tmpKey];
+
+  return tmpKey;
 }
 
 export function createOsKeyFromUseragent(useragent: string) {

--- a/profiler/lib/Oses.ts
+++ b/profiler/lib/Oses.ts
@@ -1,5 +1,6 @@
 import * as Fs from 'fs';
 import * as Path from 'path';
+import IOperatingSystem from '../interfaces/IOperatingSystem';
 
 export const FILE_PATH = Path.join(__dirname, '../data/oses.json');
 
@@ -17,19 +18,6 @@ export default class Oses {
 }
 
 // INTERFACES
-
-export interface IOperatingSystem {
-  key: string;
-  name: string;
-  desktopPercent: number;
-  version: IOperatingSystemVersion;
-}
-
-export interface IOperatingSystemVersion {
-  major: string;
-  minor: string;
-  name?: string;
-}
 
 export interface IByKey {
   [key: string]: IOperatingSystem

--- a/profiler/run.ts
+++ b/profiler/run.ts
@@ -50,7 +50,7 @@ process.on('exit', () => {
 
 function getRunnerForAgent(agent: IBrowserstackAgent) {
   return async () => {
-    const response = await fetch(`http://${runnerDomain}:3000/profiler`, {
+    const response = await fetch(`http://${runnerDomain}:3000/`, {
       headers: {
         scraper: 'profiler',
       },

--- a/runner/interfaces/IAssignment.ts
+++ b/runner/interfaces/IAssignment.ts
@@ -1,12 +1,13 @@
 import IAssignmentPage from './IAssignmentPage';
+import { IBrowserToTestPickType, IBrowserToTestUsagePercent } from '@double-agent/profiler/lib/BrowsersToTest';
 
 export default interface IAssignment {
   id: number;
   useragent: string;
+  pickType: IBrowserToTestPickType;
   profileDirName: string;
-  percentOfTraffic: number;
-  testType: 'intoli' | 'topBrowsers';
+  usagePercent: IBrowserToTestUsagePercent;
   pages: IAssignmentPage[];
-  sessionid: string;
+  sessionId: string;
   isCompleted?: boolean;
 }


### PR DESCRIPTION
A few small changes.
- profiler/data/browsersToTest.json now combines all tests into single array with a pickType array (random or majority) that determines how scoring works.
- We are now generating 50 unique osKey+browserKey combinations from Intoli.
- session.json files now output pctBot and pickType.
- sessionid is now sessionId (with a capital "I")
- osKey, browserKey, and profile folder names now use dashes ("-") instead of underscores ("_").

Updated profiler/data/profiles files coming in subsequent PR.