### PR TITLE
resolve dep warning rmdirSync in analyze script

### DIFF
--- a/runner/scripts/4-analyzeAssignmentResults.ts
+++ b/runner/scripts/4-analyzeAssignmentResults.ts
@@ -38,7 +38,7 @@ function saveFlagsToPluginFiles(saveToDir: string, flags: IResultFlag[]) {
     flagsByPluginId[flag.pluginId] = flagsByPluginId[flag.pluginId] || [];
     flagsByPluginId[flag.pluginId].push(flag);
   });
-  if (Fs.existsSync(saveToDir)) Fs.rmdirSync(saveToDir, { recursive: true });
+  if (Fs.existsSync(saveToDir)) Fs.rmSync(saveToDir, { recursive: true });
   Fs.mkdirSync(saveToDir, { recursive: true });
 
   for (const pluginId of Object.keys(flagsByPluginId)) {


### PR DESCRIPTION
resolves deprecation warning (`rmSync` instead of `rmdirSync`)
in 4-analyzeAssignmentResults.ts

(I use NodeJS 17, was in v14 also already deprecated however)