### PR TITLE
multi runner support

### DIFF
--- a/runner/interfaces/runner.ts
+++ b/runner/interfaces/runner.ts
@@ -1,0 +1,36 @@
+import IAssignment from '@double-agent/collect-controller/interfaces/IAssignment';
+
+// Each assignment requires a fresh runner. The runner is created
+// by a factory object implementing this interface.
+interface IRunnerFactory {
+    // creation of resources and any other kind of preparative initialization/configuration
+    // work is to be done within this function. If this method fails it is up to the
+    // implementation to clean up the resources it already created in the process.
+    // On the condition that this function did succeed it can be relied upon
+    // that the factory user will call stopFactory under any circumstance.
+    startFactory(): Promise<void>;
+
+    // spawnRunner is the function used to create/spawn a new runner,
+    // used for the assignment given to this function. It will be stopped
+    // under any circumstance by the factory user when the assignment
+    // finished successfully or got abruptly ended due to an error.
+    spawnRunner(assignment: IAssignment): Promise<IRunner>;
+
+    // stopFactory is to be used to clean up any resources created
+    // in the lifetime of this factory object, starting since
+    // the call of startFactory. This function will not be called in case
+    // the construction of the factory or the call to startFactory threw an error,
+    stopFactory(): Promise<void>;
+}
+
+// IRunner is the interface used for a runner which
+// is to successfully complete any IAssignment thrown its way.
+interface IRunner {
+    // run the assignment and return only when finished.
+    run(assignment: IAssignment): Promise<void>;
+
+    // clean up any resources owned by the Runner implementation.
+    stop(): Promise<void>;
+}
+
+export { IRunnerFactory, IRunner };

--- a/runner/lib/runAssignmentInHero.ts
+++ b/runner/lib/runAssignmentInHero.ts
@@ -1,9 +1,9 @@
 import Hero from '@ulixee/hero-fullstack';
 import Core from '@ulixee/hero-core';
 import { IRunnerFactory, IRunner } from '../interfaces/runner';
-import IAssignment from '@double-hero/collect-controller/interfaces/IAssignment';
+import IAssignment from '@double-agent/collect-controller/interfaces/IAssignment';
 import RealUserAgents from '@double-agent/real-user-agents';
-import ISessionPage from '@double-hero/collect/interfaces/ISessionPage';
+import ISessionPage from '@double-agent/collect/interfaces/ISessionPage';
 
 class HeroRunnerFactory implements IRunnerFactory {
   public async startFactory() {

--- a/runner/lib/runAssignmentInHero.ts
+++ b/runner/lib/runAssignmentInHero.ts
@@ -1,68 +1,104 @@
 import Hero from '@ulixee/hero-fullstack';
-import IAssignment from '@double-agent/collect-controller/interfaces/IAssignment';
-import ISessionPage from '@double-agent/collect/interfaces/ISessionPage';
+import Core from '@ulixee/hero-core';
+import { IRunnerFactory, IRunner } from '../interfaces/runner';
+import IAssignment from '@double-hero/collect-controller/interfaces/IAssignment';
+import RealUserAgents from '@double-agent/real-user-agents';
+import ISessionPage from '@double-hero/collect/interfaces/ISessionPage';
 
-let lastPage: ISessionPage;
+class HeroRunnerFactory implements IRunnerFactory {
+  public async startFactory() {
+    await Core.start();
+  }
 
-export default async function runAssignmentInHero(hero: Hero, assignment: IAssignment) {
-  console.log('--------------------------------------');
-  console.log('STARTING ', assignment.id, assignment.userAgentString);
-  console.log('Session ID: ', await hero.sessionId);
-  let counter = 0;
-  try {
-    for (const pages of Object.values(assignment.pagesByPlugin)) {
-      counter = await runPluginPages(hero, assignment, pages, counter);
-    }
-    console.log(`[%s.✔] FINISHED ${assignment.id}`, assignment.num);
-  } catch (err) {
-    console.log('[%s.x] Error on %s', assignment.num, lastPage?.url, err);
-    process.exit();
+  public async spawnRunner(assignment: IAssignment): Promise<IRunner> {
+    const agentMeta = RealUserAgents.extractMetaFromUserAgentId(assignment.userAgentId);
+    const hero = new Hero({
+      userAgent: `~ ${agentMeta.operatingSystemName} = ${agentMeta.operatingSystemVersion.replace(
+        '-',
+        '.',
+      )} & ${agentMeta.browserName} = ${agentMeta.browserVersion.replace('-0', '')}`,
+    });
+    return new HeroRunner(hero);
+  }
+
+  public async stopFactory() {
+    return;
   }
 }
 
-async function runPluginPages(
-  hero: Hero,
-  assignment: IAssignment,
-  pages: ISessionPage[],
-  counter: number,
-) {
-  let isFirst = true;
-  for (const page of pages) {
-    lastPage = page;
-    const step = `[${assignment.num}.${counter}]`;
-    if (page.isRedirect) continue;
-    if (isFirst || page.url !== (await hero.url)) {
-      console.log('%s GOTO -- %s', step, page.url);
-      const resource = await hero.goto(page.url);
-      console.log('%s Waiting for statusCode -- %s', step, page.url);
-      const statusCode = await resource.response.statusCode;
-      if (statusCode >= 400) {
-        console.log(`${statusCode} ERROR: `, await resource.response.text);
-        console.log(page.url);
-        process.exit();
+class HeroRunner implements IRunner {
+  lastPage?: ISessionPage;
+  hero: Hero;
+
+  constructor(hero: Hero) {
+    this.hero = hero;
+  }
+
+  public async run(assignment: IAssignment) {
+    console.log('--------------------------------------');
+    console.log('STARTING ', assignment.id, assignment.userAgentString);
+    console.log('Session ID: ', await this.hero.sessionId);
+    let counter = 0;
+    try {
+      for (const pages of Object.values(assignment.pagesByPlugin)) {
+        counter = await this.runPluginPages(assignment, pages, counter);
       }
+      console.log(`[%s.✔] FINISHED ${assignment.id}`, assignment.num);
+    } catch (err) {
+      console.log('[%s.x] Error on %s', assignment.num, this.lastPage?.url, err);
+      process.exit();
     }
-    isFirst = false;
-    console.log('%s waitForPaintingStable -- %s', step, page.url);
-    await hero.waitForPaintingStable();
-
-    if (page.waitForElementSelector) {
-      console.log('%s waitForElementSelector -- %s', step, page.waitForElementSelector);
-      const element = hero.document.querySelector(page.waitForElementSelector);
-      await hero.waitForElement(element, { waitForVisible: true, timeoutMs: 60e3 });
-    }
-
-    if (page.clickElementSelector) {
-      console.log('%s Wait for clickElementSelector -- %s', step, page.clickElementSelector);
-      const clickable = hero.document.querySelector(page.clickElementSelector);
-      await hero.waitForElement(clickable, { waitForVisible: true });
-      console.log('%s Click -- %s', step, page.clickElementSelector);
-      await hero.click(clickable);
-      await hero.waitForLocation('change');
-      console.log('%s Location Changed -- %s', step, page.url);
-    }
-    counter += 1;
   }
 
-  return counter;
+  async runPluginPages(
+    assignment: IAssignment,
+    pages: ISessionPage[],
+    counter: number,
+  ) {
+    let isFirst = true;
+    for (const page of pages) {
+      this.lastPage = page;
+      const step = `[${assignment.num}.${counter}]`;
+      if (page.isRedirect) continue;
+      if (isFirst || page.url !== (await this.hero.url)) {
+        console.log('%s GOTO -- %s', step, page.url);
+        const resource = await this.hero.goto(page.url);
+        console.log('%s Waiting for statusCode -- %s', step, page.url);
+        const statusCode = await resource.response.statusCode;
+        if (statusCode >= 400) {
+          console.log(`${statusCode} ERROR: `, await resource.response.text());
+          console.log(page.url);
+          process.exit();
+        }
+      }
+      isFirst = false;
+      console.log('%s waitForPaintingStable -- %s', step, page.url);
+      await this.hero.waitForPaintingStable();
+
+      if (page.waitForElementSelector) {
+        console.log('%s waitForElementSelector -- %s', step, page.waitForElementSelector);
+        const element = this.hero.document.querySelector(page.waitForElementSelector);
+        await this.hero.waitForElement(element, { waitForVisible: true, timeoutMs: 60e3 });
+      }
+
+      if (page.clickElementSelector) {
+        console.log('%s Wait for clickElementSelector -- %s', step, page.clickElementSelector);
+        const clickable = this.hero.document.querySelector(page.clickElementSelector);
+        await this.hero.waitForElement(clickable, { waitForVisible: true });
+        console.log('%s Click -- %s', step, page.clickElementSelector);
+        await this.hero.click(clickable);
+        await this.hero.waitForLocation('change');
+        console.log('%s Location Changed -- %s', step, page.url);
+      }
+      counter += 1;
+    }
+
+    return counter;
+  }
+
+  async stop() {
+    await this.hero.close();
+  }
 }
+
+export { HeroRunnerFactory };

--- a/runner/lib/runAssignmentInSecretAgent.ts
+++ b/runner/lib/runAssignmentInSecretAgent.ts
@@ -1,68 +1,111 @@
 import { Agent } from 'secret-agent';
+import Core from '@secret-agent/core';
+import { IRunnerFactory, IRunner } from '../interfaces/runner';
 import IAssignment from '@double-agent/collect-controller/interfaces/IAssignment';
 import ISessionPage from '@double-agent/collect/interfaces/ISessionPage';
 
-let lastPage: ISessionPage;
+class SecretAgentRunnerFactory implements IRunnerFactory {
+  connectionServerPort: number;
+  connectionToCore: { host: string };
 
-export default async function runAssignmentInSecretAgent(agent: Agent, assignment: IAssignment) {
-  console.log('--------------------------------------');
-  console.log('STARTING ', assignment.id, assignment.userAgentString);
-  console.log('Session ID: ', await agent.sessionId);
-  let counter = 0;
-  try {
-    for (const pages of Object.values(assignment.pagesByPlugin)) {
-      counter = await runPluginPages(agent, assignment, pages, counter);
-    }
-    console.log(`[%s.✔] FINISHED ${assignment.id}`, assignment.num);
-  } catch (err) {
-    console.log('[%s.x] Error on %s', assignment.num, lastPage?.url, err);
-    process.exit();
+  constructor(port: number) {
+    this.connectionServerPort = port;
+    this.connectionToCore = {
+      host: `localhost:${port}`,
+    };
+  }
+
+  public async startFactory() {
+    Core.onShutdown = () => process.exit();
+    await Core.start({ coreServerPort: this.connectionServerPort });
+  }
+
+  public async spawnRunner(assignment: IAssignment): Promise<IRunner> {
+    const agent = new Agent({
+      connectionToCore: this.connectionToCore,
+      userAgent: assignment.userAgentString,
+    });
+    return new SecretAgentRunner(agent);
+  }
+
+  public async stopFactory() {
+    return;
   }
 }
 
-async function runPluginPages(
-  agent: Agent,
-  assignment: IAssignment,
-  pages: ISessionPage[],
-  counter: number,
-) {
-  let isFirst = true;
-  for (const page of pages) {
-    lastPage = page;
-    const step = `[${assignment.num}.${counter}]`;
-    if (page.isRedirect) continue;
-    if (isFirst || page.url !== (await agent.url)) {
-      console.log('%s GOTO -- %s', step, page.url);
-      const resource = await agent.goto(page.url);
-      console.log('%s Waiting for statusCode -- %s', step, page.url);
-      const statusCode = await resource.response.statusCode;
-      if (statusCode >= 400) {
-        console.log(`${statusCode} ERROR: `, await resource.response.text());
-        console.log(page.url);
-        process.exit();
+class SecretAgentRunner implements IRunner {
+  lastPage?: ISessionPage;
+  agent: Agent;
+
+  constructor(agent: Agent) {
+    this.agent = agent;
+  }
+
+  public async run(assignment: IAssignment) {
+    console.log('--------------------------------------');
+    console.log('STARTING ', assignment.id, assignment.userAgentString);
+    console.log('Session ID: ', await this.agent.sessionId);
+    let counter = 0;
+    try {
+      for (const pages of Object.values(assignment.pagesByPlugin)) {
+        counter = await this.runPluginPages(assignment, pages, counter);
       }
+      console.log(`[%s.✔] FINISHED ${assignment.id}`, assignment.num);
+    } catch (err) {
+      console.log('[%s.x] Error on %s', assignment.num, this.lastPage?.url, err);
+      process.exit();
     }
-    isFirst = false;
-    console.log('%s waitForPaintingStable -- %s', step, page.url);
-    await agent.waitForPaintingStable();
-
-    if (page.waitForElementSelector) {
-      console.log('%s waitForElementSelector -- %s', step, page.waitForElementSelector);
-      const element = agent.document.querySelector(page.waitForElementSelector);
-      await agent.waitForElement(element, { waitForVisible: true, timeoutMs: 60e3 });
-    }
-
-    if (page.clickElementSelector) {
-      console.log('%s Wait for clickElementSelector -- %s', step, page.clickElementSelector);
-      const clickable = agent.document.querySelector(page.clickElementSelector);
-      await agent.waitForElement(clickable, { waitForVisible: true });
-      console.log('%s Click -- %s', step, page.clickElementSelector);
-      await agent.click(clickable);
-      await agent.waitForLocation('change');
-      console.log('%s Location Changed -- %s', step, page.url);
-    }
-    counter += 1;
   }
 
-  return counter;
+  async runPluginPages(
+    assignment: IAssignment,
+    pages: ISessionPage[],
+    counter: number,
+  ) {
+    let isFirst = true;
+    for (const page of pages) {
+      this.lastPage = page;
+      const step = `[${assignment.num}.${counter}]`;
+      if (page.isRedirect) continue;
+      if (isFirst || page.url !== (await this.agent.url)) {
+        console.log('%s GOTO -- %s', step, page.url);
+        const resource = await this.agent.goto(page.url);
+        console.log('%s Waiting for statusCode -- %s', step, page.url);
+        const statusCode = await resource.response.statusCode;
+        if (statusCode >= 400) {
+          console.log(`${statusCode} ERROR: `, await resource.response.text());
+          console.log(page.url);
+          process.exit();
+        }
+      }
+      isFirst = false;
+      console.log('%s waitForPaintingStable -- %s', step, page.url);
+      await this.agent.waitForPaintingStable();
+
+      if (page.waitForElementSelector) {
+        console.log('%s waitForElementSelector -- %s', step, page.waitForElementSelector);
+        const element = this.agent.document.querySelector(page.waitForElementSelector);
+        await this.agent.waitForElement(element, { waitForVisible: true, timeoutMs: 60e3 });
+      }
+
+      if (page.clickElementSelector) {
+        console.log('%s Wait for clickElementSelector -- %s', step, page.clickElementSelector);
+        const clickable = this.agent.document.querySelector(page.clickElementSelector);
+        await this.agent.waitForElement(clickable, { waitForVisible: true });
+        console.log('%s Click -- %s', step, page.clickElementSelector);
+        await this.agent.click(clickable);
+        await this.agent.waitForLocation('change');
+        console.log('%s Location Changed -- %s', step, page.url);
+      }
+      counter += 1;
+    }
+
+    return counter;
+  }
+
+  async stop() {
+    await this.agent.close();
+  }
 }
+
+export { SecretAgentRunnerFactory };

--- a/runner/package.json
+++ b/runner/package.json
@@ -24,7 +24,8 @@
     "node-fetch": "^2.6.1",
     "p-queue": "^6.6.2",
     "puppeteer": "2.1.1",
-    "unzipper": "^0.10.11"
+    "unzipper": "^0.10.11",
+    "commander": "^9.0.0"
   },
   "devDependencies": {
     "@types/puppeteer": "2.0.0"

--- a/runner/package.json
+++ b/runner/package.json
@@ -8,6 +8,9 @@
     "1": "node -r source-map-support/register --max-old-space-size=10000 scripts/1-extractFoundationalProbes.js",
     "2": "node -r source-map-support/register scripts/2-collectUserAgentsToTest.js",
     "3": "node -r source-map-support/register scripts/3-runAssignments.js",
+    "3-hero": "yarn 3",
+    "3-secretAgent": "node -r source-map-support/register scripts/3-runAssignments.js --runner=secret-agent",
+    "3-puppeteer": "node -r source-map-support/register scripts/3-runAssignments.js --runner=puppeteer",
     "4": "node -r source-map-support/register scripts/4-analyzeAssignmentResults.js"
   },
   "dependencies": {

--- a/runner/scripts/0-collectFoundationalProfiles.ts
+++ b/runner/scripts/0-collectFoundationalProfiles.ts
@@ -3,7 +3,7 @@ import * as Path from 'path';
 import Puppeteer from 'puppeteer';
 import IAssignment from '@double-agent/collect-controller/interfaces/IAssignment';
 import RealUserAgents from "@double-agent/real-user-agents";
-import runAssignmentInPuppeteer from '../lib/runAssignmentInPuppeteer';
+import runAssignmentInPuppeteer from '../lib/PuppeteerRunnerFactory';
 import cleanPuppeteerPageCache from '../lib/cleanPuppeteerPageCache';
 import assignmentServer from '../lib/assignmentServer';
 import saveAssignmentToProfileDir from '../lib/saveAssignmentToProfileDir';

--- a/runner/scripts/3-runAssignments.ts
+++ b/runner/scripts/3-runAssignments.ts
@@ -1,45 +1,134 @@
 import * as Path from 'path';
-import IAssignment from '@double-agent/collect-controller/interfaces/IAssignment';
-import Core from '@ulixee/hero-core';
-import Hero from '@ulixee/hero-fullstack';
-import RealUserAgents from '@double-agent/real-user-agents';
-import runAssignmentInHero from '../lib/runAssignmentInHero';
+import { HeroRunnerFactory } from '../lib/runAssignmentInHero';
+import { SecretAgentRunnerFactory } from '../lib/runAssignmentInSecretAgent';
+import { PuppeteerRunnerFactory } from '../lib/runAssignmentInPuppeteer';
 import forEachAssignment from '../lib/forEachAssignment';
+import { IRunnerFactory, IRunner } from '../interfaces/runner';
+import { program } from 'commander';
+import { exit } from 'process';
+
+// RunnerID groups together all supported runner implementations.
+enum RunnerID {
+  Puppeteer = 'puppeteer',
+  SecretAgent = 'secret-agent',
+  Hero = 'hero',
+}
+
+function parseRunnerID(value: string, previous: RunnerID): RunnerID {
+  switch (value.toLowerCase().trim()) {
+    case "hero": {
+      return RunnerID.Hero;
+    }
+
+    case "secret-agent":
+    case "secretagent":
+    case "sa": {
+      return RunnerID.SecretAgent;
+    }
+
+    case "puppeteer":
+    case "pptr": {
+      return RunnerID.Puppeteer;
+    }
+
+    default: {
+      console.warn(`parseRunnerID: ignore unrecognized runner value: '${value}'`);
+      return previous;
+    }
+  }
+}
+
+function parseNumber(value: string): number {
+  return parseInt(value);
+}
+
+program
+  .option('-r, --runner <hero|sa|secret-agent|pptr|puppeteer>', 'select the runner to run', parseRunnerID, RunnerID.Hero)
+  .option('--secret-agent-port <port>', 'select port to use for secret agent (flag only used if puppeteer runner is selected)', parseNumber, 7007);
+program.parse();
+const options = program.opts();
 
 // process.env.SA_SHOW_BROWSER = 'true';
 process.env.SA_SHOW_REPLAY = 'false';
 
 const TYPE = 'external';
 
-(async function run() {
-  await Core.start();
+async function runFactoryRunners(runnerID: RunnerID, runnerFactory: IRunnerFactory) {
+  console.log(`run all assignments for runner: ${runnerID}!`);
 
-  const runAssignment = async (assignment: IAssignment) => {
-    const agentMeta = RealUserAgents.extractMetaFromUserAgentId(assignment.userAgentId);
-
-    const agent = new Hero({
-      userAgent: `~ ${agentMeta.operatingSystemName} = ${agentMeta.operatingSystemVersion.replace(
-        '-',
-        '.',
-      )} & ${agentMeta.browserName} = ${agentMeta.browserVersion.replace('-0', '')}`,
-    });
-    console.log(assignment.userAgentString);
-    console.log('AGENT: ', await agent.meta);
-    await runAssignmentInHero(agent as any, assignment);
-    await agent.close();
-  };
-  const userAgentsToTestPath = Path.join(
-    __dirname,
-    `../data/${TYPE}/2-user-agents-to-test/userAgentsToTest`,
-  );
-
+  const userAgentsToTestPath = Path.join(__dirname, `../data/${TYPE}/2-user-agents-to-test/userAgentsToTest`);
   const config = {
-    userId: 'testing',
+    userId: `runner-${runnerID}`,
     dataDir: Path.resolve(__dirname, `../data/${TYPE}/3-assignments`),
     concurrency: 1,
     userAgentsToTestPath,
   };
-  await forEachAssignment(config, assignment => runAssignment(assignment));
-})()
-  .then(() => process.exit())
-  .catch(console.log);
+
+  await forEachAssignment(config, async (assignment) => {
+    let runner: IRunner;
+    try {
+      runner = await runnerFactory.spawnRunner(assignment);
+    } catch (error) {
+      console.error(`failed to create runner ${runnerID}: ${error}`);
+      return;
+    }
+    try {
+      await runner.run(assignment);
+    } catch (error) {
+      console.error(`runner ${runnerID} run failed with exception: ${error}`);
+    } finally {
+      try {
+        await runner.stop();
+      } catch (error) {
+        console.error(`failed to stop runner ${runnerID}: ${error}`);
+      }
+    }
+  });
+}
+
+async function run() {
+  const runnerId = options.runner || RunnerID.Puppeteer;
+  let runnerFactory: IRunnerFactory;
+
+  switch (runnerId) {
+    case RunnerID.Puppeteer: {
+      runnerFactory = new PuppeteerRunnerFactory();
+      break;
+    }
+
+    case RunnerID.SecretAgent: {
+      runnerFactory = new SecretAgentRunnerFactory(options.secretAgentPort);
+      break;
+    }
+
+    case RunnerID.Hero: {
+      runnerFactory = new HeroRunnerFactory();
+      break;
+    }
+
+    default:
+      console.error(`ignoring runner with id ${runnerId}: unsupported`);
+      exit(1);
+  }
+
+  try {
+    await runnerFactory.startFactory();
+  } catch (error) {
+    console.error(`failed to start runner factory ${runnerId}: ${error}`);
+    return;
+  }
+
+  try {
+    await runFactoryRunners(runnerId, runnerFactory);
+  } catch (error) {
+    console.error(`failed to run runners for factory runner with runner Id ${runnerId}: ${error}`);
+  } finally {
+    try {
+      await runnerFactory.stopFactory();
+    } catch (error) {
+      console.error(`failed to stop runner factory with Id ${runnerId}: ${error}`);
+    }
+  }
+}
+
+run().then(() => process.exit()).catch(console.log);

--- a/runner/scripts/3-runAssignments.ts
+++ b/runner/scripts/3-runAssignments.ts
@@ -1,34 +1,34 @@
 import * as Path from 'path';
-import { HeroRunnerFactory } from '../lib/runAssignmentInHero';
-import { SecretAgentRunnerFactory } from '../lib/runAssignmentInSecretAgent';
-import { PuppeteerRunnerFactory } from '../lib/runAssignmentInPuppeteer';
+import HeroRunnerFactory from '../lib/HeroRunnerFactory';
+import SecretAgentRunnerFactory from '../lib/SecretAgentRunnerFactory';
+import PuppeteerRunnerFactory from '../lib/PuppeteerRunnerFactory';
 import forEachAssignment from '../lib/forEachAssignment';
 import { IRunnerFactory, IRunner } from '../interfaces/runner';
 import { program } from 'commander';
 import { exit } from 'process';
 
-// RunnerID groups together all supported runner implementations.
-enum RunnerID {
+// RunnerId groups together all supported runner implementations.
+enum RunnerId {
   Puppeteer = 'puppeteer',
   SecretAgent = 'secret-agent',
   Hero = 'hero',
 }
 
-function parseRunnerID(value: string, previous: RunnerID): RunnerID {
+function parseRunnerID(value: string, previous: RunnerId): RunnerId {
   switch (value.toLowerCase().trim()) {
     case "hero": {
-      return RunnerID.Hero;
+      return RunnerId.Hero;
     }
 
     case "secret-agent":
     case "secretagent":
     case "sa": {
-      return RunnerID.SecretAgent;
+      return RunnerId.SecretAgent;
     }
 
     case "puppeteer":
     case "pptr": {
-      return RunnerID.Puppeteer;
+      return RunnerId.Puppeteer;
     }
 
     default: {
@@ -43,7 +43,7 @@ function parseNumber(value: string): number {
 }
 
 program
-  .option('-r, --runner <hero|sa|secret-agent|pptr|puppeteer>', 'select the runner to run', parseRunnerID, RunnerID.Hero)
+  .option('-r, --runner <hero|sa|secret-agent|pptr|puppeteer>', 'select the runner to run', parseRunnerID, RunnerId.Hero)
   .option('--secret-agent-port <port>', 'select port to use for secret agent (flag only used if secret agent runner is selected)', parseNumber, 7007);
 program.parse();
 const options = program.opts();
@@ -53,7 +53,7 @@ process.env.SA_SHOW_REPLAY = 'false';
 
 const TYPE = 'external';
 
-async function runFactoryRunners(runnerID: RunnerID, runnerFactory: IRunnerFactory) {
+async function runFactoryRunners(runnerID: RunnerId, runnerFactory: IRunnerFactory) {
   console.log(`run all assignments for runner: ${runnerID}!`);
 
   const userAgentsToTestPath = Path.join(__dirname, `../data/${TYPE}/2-user-agents-to-test/userAgentsToTest`);
@@ -87,21 +87,21 @@ async function runFactoryRunners(runnerID: RunnerID, runnerFactory: IRunnerFacto
 }
 
 async function run() {
-  const runnerId = options.runner || RunnerID.Puppeteer;
+  const runnerId = options.runner || RunnerId.Puppeteer;
   let runnerFactory: IRunnerFactory;
 
   switch (runnerId) {
-    case RunnerID.Puppeteer: {
+    case RunnerId.Puppeteer: {
       runnerFactory = new PuppeteerRunnerFactory();
       break;
     }
 
-    case RunnerID.SecretAgent: {
+    case RunnerId.SecretAgent: {
       runnerFactory = new SecretAgentRunnerFactory(options.secretAgentPort);
       break;
     }
 
-    case RunnerID.Hero: {
+    case RunnerId.Hero: {
       runnerFactory = new HeroRunnerFactory();
       break;
     }

--- a/runner/scripts/3-runAssignments.ts
+++ b/runner/scripts/3-runAssignments.ts
@@ -44,7 +44,7 @@ function parseNumber(value: string): number {
 
 program
   .option('-r, --runner <hero|sa|secret-agent|pptr|puppeteer>', 'select the runner to run', parseRunnerID, RunnerID.Hero)
-  .option('--secret-agent-port <port>', 'select port to use for secret agent (flag only used if puppeteer runner is selected)', parseNumber, 7007);
+  .option('--secret-agent-port <port>', 'select port to use for secret agent (flag only used if secret agent runner is selected)', parseNumber, 7007);
 program.parse();
 const options = program.opts();
 


### PR DESCRIPTION
Closes #55 

## Problem Statement

The public code base's runner can only runner secret-agent out of the box. The next public version probably will only be able to run just Hero.

There is an implementation available for puppeteer but it is more of an example and not really useable within the runner context as-is.

## Solution

The proposed solution can be found in this PR. The goal is to be able to easily start any of the implemented runners,
without having to modify code. It still isn't possible to easily inject your own runner without forking the code or modifying it all. But at least it's a step in that direction.

## Disclaimer

The secret-agent and puppeteer code should work as it was tested in my fork. The hero code I cannot attest to work out of the box, as I haven't been able to test that one. It might also require some additional resource management code, if so, take it perhaps as a starting point and help me finish it please.